### PR TITLE
Tab completion for repo names in `hub clone`

### DIFF
--- a/commands/internal_list_repos.go
+++ b/commands/internal_list_repos.go
@@ -48,10 +48,6 @@ func internalListRepos(cmd *Command, args *Args) {
 	var ownerName string
 	if len(words) > 0 {
 		ownerName = words[0]
-	} else {
-		user, err := gh.CurrentUser()
-		utils.Check(err)
-		ownerName = user.Login
 	}
 
 	repos, err := gh.FetchRepositories(ownerName)

--- a/commands/internal_list_repos.go
+++ b/commands/internal_list_repos.go
@@ -1,0 +1,69 @@
+package commands
+
+import (
+	"github.com/github/hub/ui"
+
+	"github.com/github/hub/github"
+	"github.com/github/hub/utils"
+)
+
+var (
+	flagQualified bool
+)
+
+var (
+	cmdInternalListRepos = &Command{
+		Run: internalListRepos,
+		Usage: "internal-list-repos [-q] [--qualified] [<OWNER>]",
+		Long: `List GitHub repos for a given owner.
+
+This command is for hub's internal use only. It may change or go away 
+at any time. Do not code against it.
+
+## Options:
+    <OWNER>
+        The user or organization to list repos for. Defaults to your own
+        GitHub username.
+
+    -q, --qualified
+        Include the "<USER>/" prefix on all repos listed
+
+## See also:
+
+hub(1)
+`,
+	}
+)
+
+func init() {
+	cmdInternalListRepos.Flag.BoolVarP(&flagQualified, "qualified", "q", false, "QUALIFY")
+
+	CmdRunner.Use(cmdInternalListRepos)
+}
+
+func internalListRepos(cmd *Command, args *Args) {
+	gh := github.NewClient(github.GitHubHost)
+
+	words := args.Words()
+	var ownerName string
+	if len(words) > 0 {
+		ownerName = words[0]
+	} else {
+		user, err := gh.CurrentUser()
+		utils.Check(err)
+		ownerName = user.Login
+	}
+
+	repos, err := gh.FetchRepositories(ownerName)
+	utils.Check(err)
+
+	for _, repo := range repos {
+		if flagQualified {
+			ui.Printf("%s/%s\n", ownerName, repo.Name)
+		} else {
+			ui.Printf("%s\n", repo.Name)
+		}
+	}
+
+	args.NoForward()
+}

--- a/etc/hub.zsh_completion
+++ b/etc/hub.zsh_completion
@@ -67,6 +67,100 @@ __hub_setup_zsh_fns () {
         '::issue-url:_urls'
   }
 
+  (( $+functions[__hub_github_repositories] )) ||
+  __hub_github_repositories () {
+    local -a tokens
+    local user
+    tokens=(${(@s:/:)PREFIX})
+    if [[ $PREFIX =~ "/" ]]; then
+      user="$tokens[1]"
+      repo_names=("${(@f)$(hub internal-list-repos --qualified $user)}")
+    else
+      repo_names=("${(@f)$(hub internal-list-repos)}")
+    fi
+    _wanted hub-repositories expl 'GitHub repositories' compadd -a repo_names
+  }
+
+  (( $+functions[__hub_some_repositories] )) ||
+  __hub_some_repositories () {
+    _alternative \
+      'hub-repositories::__hub_github_repositories' \
+      'local-repositories::__git_local_repositories' \
+      'remote-repositories::__git_remote_repositories'
+  }
+
+  # This function definition must be unconditional, because we are 
+  # clobbering ZSH's definition of it.
+  __git_any_repositories () {
+    _alternative \
+      'hub-repositories::__hub_github_repositories' \
+      'local-repositories::__git_local_repositories' \
+      'remotes: :__git_remotes' \
+      'remote-repositories::__git_remote_repositories'
+  }
+
+  # This function definition must be unconditional, because we are 
+  # clobbering ZSH's definition of it.
+  # This is a straight copy of Zsh's _git-clone, except that we
+  # use __hub_some_repositories intead of __git_any_repositories, so
+  # we can include GitHub repo names, and exclude remotes, which shouldn't
+  # be used in this context in the first place.
+  _git-clone () {
+    local curcontext=$curcontext state line ret=1
+    declare -A opt_args
+
+    # TODO: Argument to -o should be a remote name.
+    # TODO: Argument to -b should complete branch names in the repository being
+    # cloned (see __git_references())
+    _arguments -C -S -s \
+      '(-l --local --no-local)'{-l,--local}'[clone locally, hardlink refs and objects if possible]' \
+      '(-l --local --no-local)--no-local[override --local, as if file:/// URL was given]' \
+      '--no-hardlinks[copy files instead of hardlinking when doing a local clone]' \
+      '(-s --shared)'{-s,--shared}'[share the objects with the source repository (warning: see man page)]' \
+      '(-j --jobs)'{-j+,--jobs=}'[specify number of submodules cloned in parallel]:jobs' \
+      '--reference[reference repository]:repository:_directories' \
+      '--reference-if-able[reference repository]:repository:_directories' \
+      '--dissociate[make the newly-created repository independent of the --reference repository]' \
+      '(-q --quiet)'{-q,--quiet}'[operate quietly]' \
+      '(-v --verbose)'{-v,--verbose}'[always display the progressbar]' \
+      '--progress[output progress even if stderr is not a terminal]' \
+      '(-n --no-checkout)'{-n,--no-checkout}'[do not checkout HEAD after clone is complete]' \
+      '(-o --origin)--bare[make a bare GIT repository]' \
+      '(--bare)--mirror[clone refs into refs/* instead of refs/remotes/origin/*]' \
+      '(-o --origin --bare)'{-o+,--origin=}'[use given remote name instead of "origin"]: :__git_guard_branch-name' \
+      '(-b --branch)'{-b+,--branch=}'[point HEAD to the given branch]: :__git_guard_branch-name' \
+      '(-u --upload-pack)'{-u+,--upload-pack=}'[specify path to git-upload-pack on remote side]:remote path' \
+      '--template=[directory to use as a template for the object database]: :_directories' \
+      '*'{-c,--config}'[<key>=<value> set a configuration variable in the newly created repository]' \
+      '--depth[create a shallow clone, given number of revisions deep]: :__git_guard_number depth' \
+      '--shallow-since=[shallow clone since a specific time]:time' \
+      '*--shallow-exclude=[shallow clone excluding commits reachable from specified remote revision]:revision' \
+      '(--no-single-branch)--single-branch[clone only history leading up to the main branch or the one specified by -b]' \
+      '(--single-branch)--no-single-branch[clone history leading up to each branch]' \
+      "--no-tags[don't clone any tags and make later fetches not follow them]" \
+      '--shallow-submodules[any cloned submodules will be shallow]' \
+      '--recursive[initialize all contained submodules]' \
+      '--recurse-submodules=-[initialize submodules in the clone]::file:__git_files' \
+      '--separate-git-dir[place .git dir outside worktree]:path to .git dir:_path_files -/' \
+      '(-4 --ipv4 -6 --ipv6)'{-4,--ipv4}'[use IPv4 addresses only]' \
+      '(-4 --ipv4 -6 --ipv6)'{-6,--ipv6}'[use IPv6 addresses only]' \
+      '--filter=[object filtering]:filter:_git_rev-list_filters' \
+      ': :->repository' \
+      ': :_directories' && ret=0
+
+    case $state in
+      (repository)
+        if [[ -n ${opt_args[(I)-l|--local|--no-hardlinks|-s|--shared|--reference]} ]]; then
+          __git_local_repositories && ret=0
+        else
+          __hub_some_repositories && ret=0
+        fi
+        ;;
+    esac
+
+    return ret
+  }
+
   # stash the "real" command for later
   functions[_hub_orig_git_commands]=$functions[_git_commands]
 
@@ -170,4 +264,4 @@ _hub () {
 }
 
 # make sure we actually attempt to complete on the first "tab" from the user
-_hub
+_hub "$@"

--- a/github/client.go
+++ b/github/client.go
@@ -205,7 +205,12 @@ func (client *Client) FetchRepositories(owner string) (repos []Repository, err e
 	var res *simpleResponse
 	repos = []Repository{}
 
-	path := fmt.Sprintf("users/%s/repos?per_page=100", owner)
+	var path string
+	if owner == "" {
+		path = "user/repos?per_page=100"
+	} else {
+		path = fmt.Sprintf("users/%s/repos?per_page=100", owner)
+	}
 	for path != "" {
 		res, err = api.Get(path)
 		if err = checkStatus(200, "fetching repositories", res, err); err != nil {

--- a/github/client.go
+++ b/github/client.go
@@ -196,6 +196,32 @@ func (client *Client) GistPatch(id string) (patch io.ReadCloser, err error) {
 	return res.Body, nil
 }
 
+func (client *Client) FetchRepositories(owner string) (repos []Repository, err error) {
+	api, err := client.simpleApi()
+	if err != nil {
+		return
+	}
+
+	var res *simpleResponse
+	repos = []Repository{}
+
+	path := fmt.Sprintf("users/%s/repos?per_page=100", owner)
+	for path != "" {
+		res, err = api.Get(path)
+		if err = checkStatus(200, "fetching repositories", res, err); err != nil {
+			return
+		}
+		path = res.Link("next")
+
+		reposPage := []Repository{}
+		if err = res.Unmarshal(&reposPage); err != nil {
+			return
+		}
+		repos = append(repos, reposPage...)
+	}
+	return
+}
+
 func (client *Client) Repository(project *Project) (repo *Repository, err error) {
 	api, err := client.simpleApi()
 	if err != nil {


### PR DESCRIPTION
How about some tab completion for the shorthand repo names in the `hub clone` command?

This PR adds support for tab completion of repo names in `git clone <repo>`. It supports both un-qualified repo names for the current user, and `<user>/<repo>` qualified names.

Examples:

```
hub clone <TAB>
```

will list all the current user's own repos.

```
hub clone foo<TAB>
```

will complete this user's repos starting with "foo".

```
hub clone defunkt/<TAB>
```

will list all repos for user `defunkt`.

<img width="837" alt="screen shot 2018-12-22 at 12 58 46 am" src="https://user-images.githubusercontent.com/2618447/50371246-d2162780-0584-11e9-9bed-476179e54a3d.png">

<img width="837" alt="screen shot 2018-12-22 at 12 59 07 am" src="https://user-images.githubusercontent.com/2618447/50371247-d3dfeb00-0584-11e9-85e2-467a5fd3d820.png">

### Limitations:

Does not complete user names, because there's just too darn many of them. (Maybe if the GitHub API exposed a prefix-filtered user listing endpoint, we could do that too.)

It's pretty slow right now. If this PR is accepted, I'll add some caching to it.
