### PR TITLE
Make `hub compare` work on forks

### DIFF
--- a/features/compare.feature
+++ b/features/compare.feature
@@ -19,20 +19,9 @@ Feature: hub compare
     And "open https://github.com/mislav/dotfiles/compare/my%23branch!with.special%2Bchars" should be run
 
   Scenario: No args, no upstream
-    When I run `hub compare`
-    Then the exit status should be 1
-    And the stderr should contain:
-      """
-      Usage: hub compare [-uc] [<USER>] [[<START>...]<END>]
-             hub compare [-uc] [-b <BASE>]
-      """
-
-  Scenario: Can't compare default branch to self
-    Given the default branch for "origin" is "develop"
-    And I am on the "develop" branch with upstream "origin/develop"
-    When I run `hub compare`
-    Then the exit status should be 1
-    And the stderr should contain "Usage: hub compare"
+    When I successfully run `hub compare`
+    Then there should be no output
+    And "open https://github.com/mislav/dotfiles/compare/master" should be run
 
   Scenario: No args, has upstream branch
     Given I am on the "feature" branch with upstream "origin/experimental"
@@ -40,6 +29,14 @@ Feature: hub compare
     When I successfully run `hub compare`
     Then there should be no output
     And "open https://github.com/mislav/dotfiles/compare/experimental" should be run
+
+  Scenario: No args, upstream is a fork
+    Given the "origin" remote has url "git://github.com/github/hub.git"
+    And the "sj26" remote has url "git://github.com/sj26/hub.git"
+    And I am on the "feature" branch with upstream "sj26/experimental"
+    When I successfully run `hub compare`
+    Then there should be no output
+    And "open https://github.com/sj26/hub/compare/experimental" should be run
 
   Scenario: Current branch has funky characters
     Given I am on the "feature" branch with upstream "origin/my#branch!with.special+chars"


### PR DESCRIPTION
I use `git compare` without any arguments all the time when working on feature branches in a one repository workflow - when pushing branches directly to origin and using `git compare` to open a comparison for review before opening a pull request. But it doesn't work for branches pushed to a fork.

This change makes it understand the current branch might be pushed to another remote and starts the comparison from there, then GitHub.com can figure out the default base.

It still works great for single-repo workflows and still respects the base flag for explicitly providing a base if required.

Before:

         git clone hub
         git fork
         git checkout -b some-feature
         ...
         git commit -m '...'
         git push $USER HEAD -u
         git compare

         > Usage: hub compare [-uc] [<USER>] [[<START>...]<END>]
         > hub compare [-uc] [-b <BASE>]

         git compare -b origin:master

         > Usage: hub compare [-uc] [<USER>] [[<START>...]<END>]
         > hub compare [-uc] [-b <BASE>]

         git remote -v

         > origin	https://github.com/github/hub.git (fetch)
         > origin	https://github.com/github/hub.git (push)
         > sj26	https://github.com/sj26/hub.git (fetch)
         > sj26	https://github.com/sj26/hub.git (push)

         git compare github

         > Usage: hub compare [-uc] [<USER>] [[<START>...]<END>]
         > hub compare [-uc] [-b <BASE>]

         /me gets frustrated

         git compare github HEAD

         # opens browser at:
         # https://github.com/github/hub/compare/HEAD

         git compare sj26 HEAD

         # opens browser at:
         # https://github.com/sj26/hub/compare/HEAD

         /me tears out hair

After:

         git clone hub
         git fork
         git checkout -b some-feature
         ...
         git commit -m '...'
         git push $USER HEAD -u
         git compare
         # opens browser at:
         # https://github.com/sj26/hub/compare/some-feature
         # which redirects to:
         # https://github.com/github/hub/compare/master...sj26:some-feature
         /me happily reviews commits then opens a pull request

(I used this branch to open this PR!)